### PR TITLE
Speedup

### DIFF
--- a/wotdc2j.py
+++ b/wotdc2j.py
@@ -17,7 +17,7 @@ def main():
 	
 	import struct, json, time, sys, os, shutil, datetime, base64
 
-	parserversion = "0.9.2.1"
+	parserversion = "0.9.2.2"
 	
 	global rawdata, tupledata, data, structures, numoffrags
 	global filename_source, filename_target
@@ -119,11 +119,8 @@ def main():
 	
 	if option_server == 0:
 		dossierheader['date'] = time.mktime(time.localtime())
-
-	tanksdata = dict()
-	if option_server == 0 or option_tanks == 1:
-		tanksdata = get_json_data("tanks.json")
 	
+	tanksdata = load_tanksdata()
 	structures = load_structures()
 	
 	tanks = dict()
@@ -625,19 +622,16 @@ def get_json_data(filename):
 	return file_data
 
 
-
 def get_tank_data(tanksdata, countryid, tankid, dataname):
 
 	if option_server == 0 or option_tanks == 1:
-		for tankdata in tanksdata:
-			if tankdata['countryid'] == countryid:
-				if tankdata['tankid'] == tankid:
-					return tankdata[dataname]
+		key = str(countryid) + "." + str(tankid)
+		if key in tanksdata:
+			return tanksdata[key][dataname]
 	
 	if dataname == 'title':
 		return 'unknown_' + str(countryid) + '_' + str(tankid)
-
-
+	
 	return "-"
 
 
@@ -712,6 +706,18 @@ def load_structures():
 			structures[version][category].append(item)
 	
 	return structures
+
+
+def load_tanksdata():
+	
+	tanksdata = dict()
+	if option_server == 0 or option_tanks == 1:
+		jsondata = get_json_data("tanks.json")
+		for item in jsondata:
+			key = str(item["countryid"])+"."+str(item["tankid"])
+			tanksdata[key] = item
+	
+	return tanksdata
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello, I have done some work which significantly speeds up dossier file decoding. It is achieved by changing the way structures and tanksdata are internally stored and searched through. Instead of flat lists which must be iterated, dicts are used and data are searched by keys. 

Speed gain is indeed very significant and will be even more as new versions of structures and new tanks are introduced. And also as dossier files contain more and more tanks.

Times to decode my testing dossier file (which contains some 200 tanks) are as follows:
original version: 3.45 seconds
after structures optimization: 1.29 s
after tanksdata optimization: 0.51 s

Changes are divided to 2 commits, first optimizing structures, second optimizing tanksdata, feel free to comment or propose changes, before pulling.
