### PR TITLE
Dossier file can be supplied with a path.

### DIFF
--- a/wotdc2j.py
+++ b/wotdc2j.py
@@ -17,7 +17,7 @@ def main():
 	
 	import struct, json, time, sys, os, shutil, datetime, base64
 
-	parserversion = "0.9.2.2"
+	parserversion = "0.9.2.3"
 	
 	global rawdata, tupledata, data, structures, numoffrags
 	global filename_source, filename_target
@@ -106,11 +106,11 @@ def main():
 	
 	base32name = "?;?"
 	if option_server == 0:
+		filename_base = os.path.splitext(os.path.basename(filename_source))[0]
 		try:
-			base32name = base64.b32decode(os.path.splitext(filename_source)[0].replace('.\\', ''))
+			base32name = base64.b32decode(filename_base)
 		except Exception, e:
-			if e.message != 'Incorrect padding':
-				printmessage('cannot decode filename ' + os.path.splitext(filename_source)[0] + ': ' + e.message)
+			printmessage('cannot decode filename ' + filename_base + ': ' + e.message)
 
 
 	dossierheader['server'] = base32name.split(';', 1)[0];


### PR DESCRIPTION
Hello again,
when dossier file is supplied to the script with a path, username and server are not recognized. This patch should fix it. Only case error is raised now is when base filename is not base32 encoded string, regardless of its folder path.

But there is one thing changing behaviour, I deleted the line suppressing 'Incorrect padding' error message. I suppose this line was inserted to supress annoying error messages (even if they are correct) for filenames which are not base32 encoded, but in my opinion error message could stay and inform.

But if you dont like this change, just inform me, I will add it back, so the patch will not change behaviour in such cases.
