### PR TITLE
New map Pilsen.

### DIFF
--- a/maps.json
+++ b/maps.json
@@ -51,5 +51,6 @@
 {"mapid": 70, "mapidname": "101_dday", "mapname": "Overlord"},
 {"mapid": 71, "mapidname": "111_paris", "mapname": "Icebound"},
 {"mapid": 72, "mapidname": "105_germany", "mapname": "Berlin"},
-{"mapid": 73, "mapidname": "112_eiffel_tower", "mapname": "Ravaged Capital"}
+{"mapid": 73, "mapidname": "112_eiffel_tower", "mapname": "Ravaged Capital"},
+{"mapid": 74, "mapidname": "114_czech", "mapname": "Pilsen"}
 ]

--- a/src/maps.json
+++ b/src/maps.json
@@ -54,6 +54,7 @@
 {"mapid": 71, "mapidname": "111_paris", "mapname": "Icebound"},
 {"mapid": 72, "mapidname": "105_germany", "mapname": "Berlin"},
 {"mapid": 73, "mapidname": "112_eiffel_tower", "mapname": "Ravaged Capital"},
+{"mapid": 74, "mapidname": "114_czech", "mapname": "Pilsen"},
 {"mapid": 700, "mapidname": "109_battlecity_ny", "mapname": "Winter Showdown"},
 {"mapid": 1957, "mapidname": "60_asia_miao", "mapname": "Pearl River"},
 {"mapid": 1983, "mapidname": "73_asia_korea", "mapname": "Sacred Valley"},


### PR DESCRIPTION
Hi, I have added new Pilsen map to `maps.json`.

Do we really need `maps.json` and `tanks.json` in two different locations? I tried to remove them from root dir and `wdc2j.py` seems to be working just fine. But maybe there is some special case behind this.

BTW `maps.json` and `src/maps.json` differ, which is probbaly mistake, but i didn't changed that, as i would rather remove the one in root altogether. :)